### PR TITLE
[CHORE] Fixing rendering bugs for cleaner html

### DIFF
--- a/src/components/atoms/ProjectDetailsVerificationList/ProjectDetailsVerificationList.tsx
+++ b/src/components/atoms/ProjectDetailsVerificationList/ProjectDetailsVerificationList.tsx
@@ -25,7 +25,7 @@ export const ProjectDetailsVerificationList = (props: ProjectDetailsVerification
     const verificationListToRender = []
     for (let i = 0; i < elementToRender; i++) {
       verificationListToRender.push(
-        <Text>
+        <Text key={`${verificationList[i].startDate}-${i}`}>
           {formatDate(verificationList[i].startDate, DateFormats.YYYY_MM_DD)} - {formatDate(verificationList[i].endDate, DateFormats.YYYY_MM_DD)}
         </Text>,
       )

--- a/src/components/molecules/ProjectDetailsVerification/ProjectDetailsVerification.tsx
+++ b/src/components/molecules/ProjectDetailsVerification/ProjectDetailsVerification.tsx
@@ -26,7 +26,7 @@ export const ProjectDetailsVerification = (props: ProjectDetailsVerificationProp
       <DetailWidget title={t(`verificationHeaders.verificationApproach`)}>
         {validation.verifications.length > 0 ? <Text>{validation.verifications[0].approach}</Text> : tHome(`noData`)}
       </DetailWidget>
-      <DetailWidget title={t(`verificationHeaders.verificationPeriod`)}>
+      <DetailWidget asBox title={t(`verificationHeaders.verificationPeriod`)}>
         <ProjectDetailsVerificationList verificationList={validation.verifications} />
       </DetailWidget>
     </SimpleGrid>

--- a/src/components/molecules/ProjectDetailsVerification/__snapshots__/ProjectDetailsVerification.spec.tsx.snap
+++ b/src/components/molecules/ProjectDetailsVerification/__snapshots__/ProjectDetailsVerification.spec.tsx.snap
@@ -67,8 +67,8 @@ exports[`renders correctly with validation 1`] = `
       >
         Verification Period
       </p>
-      <p
-        class="chakra-text css-0"
+      <div
+        class="css-0"
       >
         <div
           class="css-0"
@@ -88,7 +88,7 @@ exports[`renders correctly with validation 1`] = `
             View More
           </button>
         </div>
-      </p>
+      </div>
     </div>
   </div>
 </div>
@@ -153,8 +153,8 @@ exports[`renders correctly with validation and no date 1`] = `
       >
         Verification Period
       </p>
-      <p
-        class="chakra-text css-0"
+      <div
+        class="css-0"
       >
         <div
           class="css-0"
@@ -174,7 +174,7 @@ exports[`renders correctly with validation and no date 1`] = `
             View More
           </button>
         </div>
-      </p>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
# Why

Fixing rendering alerts

# What

- Can't have a `<p>` within a `<p>`
- Loops should add keys to rendered elements